### PR TITLE
Remove unnecessary merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-atomizer",
   "description": "Grunt task for Atomizer",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "main": "index.js",
   "contributors": [
     {

--- a/tasks/atomizer.js
+++ b/tasks/atomizer.js
@@ -97,7 +97,7 @@ module.exports = function (grunt) {
                 // get the config object given an array of atomic class names
                 config = atomizer.getConfig(_.keys(classNamesObj), gruntConfig, grunt.option.flags().indexOf('--verbose') > -1);
             } else {
-                config = atomizer.mergeConfigs([config, gruntConfig]);
+                config = gruntConfig;
             }
 
             // run atomizer with the config we got

--- a/tasks/atomizer.js
+++ b/tasks/atomizer.js
@@ -24,23 +24,6 @@ module.exports = function (grunt) {
     }
 
     /**
-     * helper function to handle merging array of objects
-     * @param  {mixed} a Data of the first merge param
-     * @param  {mixed} b Data of the second merge param
-     * @return {mixed}   The merged object
-     */
-    function handleMergeArrays (a, b) {
-        if (_.isArray(a) && _.isArray(b)) {
-            a.forEach(function(item){
-                if(_.findIndex(b, item) === -1) {
-                    b.push(item);
-                }
-            });
-            return b;
-        }
-    }
-
-    /**
      * TASKS
      */
     grunt.registerMultiTask('atomizer', 'Grunt plugin to execute Atomizer given a config file', function () {
@@ -113,10 +96,9 @@ module.exports = function (grunt) {
 
                 // get the config object given an array of atomic class names
                 config = atomizer.getConfig(_.keys(classNamesObj), gruntConfig, grunt.option.flags().indexOf('--verbose') > -1);
+            } else {
+                config = atomizer.mergeConfigs([config, gruntConfig]);
             }
-
-            // merge the config we have with the grunt config
-            config = _.merge(config, gruntConfig, handleMergeArrays);
 
             // run atomizer with the config we got
             content = atomizer.createCSS(config, options);


### PR DESCRIPTION
Now that `getConfig()` does a config merge behind the scenes, there's no longer a reason for the grunt task to do a merge.  